### PR TITLE
fixed bug where scrolling right (at certain screen widths) fails

### DIFF
--- a/js/jquery.flexisel.js
+++ b/js/jquery.flexisel.js
@@ -266,7 +266,7 @@
                 var difObject = (itemsWidth - innerWidth);
                 var objPosition = (object.position().left + ((totalItems-itemsVisible)*itemsWidth)-innerWidth);    
                 
-                if((difObject < Math.ceil(objPosition)) && (!settings.clone)){
+                if((difObject <= Math.ceil(objPosition)) && (!settings.clone)){
                     if (canNavigate == true) {
                         canNavigate = false;                    
     


### PR DESCRIPTION
See the following HTML for an example

```
<!DOCTYPE html>
<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
<head>
    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
    <script src='https://rawgithub.com/9bitStudios/flexisel/master/js/jquery.flexisel.js'></script>
    <meta charset="utf-8" />
    <title>Flexisel bug demonstration</title>
    <style>
        .video-gallery-wrapper .video-thumbs .video-thumb img {
            max-width: 100%;
            height: auto;
        }
        .video-gallery-wrapper .video-thumbs .video-thumb:nth-child(3n+3) {
            margin-right: 0; 
        }
        .video-gallery-wrapper .video-thumbs .video-thumb:first-child {
            padding-left: 0; 
        }
        .video-gallery-wrapper .video-thumbs .video-thumb .video-caption {
            display: block;
            padding: 10px 10px 10px 10px;
            font-size: 10pt;
            float: left;
            color: #2070b6; 
        }
        .video-gallery-wrapper .video-thumbs .video-thumb > a:after {
            clear: both;
            display: block;
            content: ""; 
        }
        .video-gallery-wrapper .nbs-flexisel-inner {
            margin-bottom: 15px; 
        }
        @media only screen and (min-width: 580px) {
            .video-thumbs .video-thumb {
                max-width: 23.5%; 
            }
            .video-thumbs .video-thumb:nth-child(4n+4) {
                margin-right: 0; 
            } 
        }
        .video-gallery-title {
            padding: 5px 5px 5px 8px;
            font-size: 14pt; 
        }
        .nbs-flexisel-container {
            position: relative;
            max-width: 100%; 
        }
        .nbs-flexisel-ul {
            position: relative;
            width: 9999px;
            margin: 0px;
            padding: 0px;
            list-style-type: none;
            text-align: left; 
        }
        .nbs-flexisel-inner {
            overflow: hidden;
            float: left;
            width: 100%;
            background: #eeeeee;
            border-top: none; 
        }
        .nbs-flexisel-item {
            float: left;
            margin: 0px;
            padding: 0px;
            cursor: pointer;
            position: relative;
            line-height: 0px; 
        }
        .nbs-flexisel-item img {
            max-width: 32%;
            padding: 1px;
            float: left; 
        }
        /*** Navigation ***/
        .nbs-flexisel-nav-left,
        .nbs-flexisel-nav-right {
            height: 40px;
            width: 40px;
            background: #fff;
            position: absolute;
            cursor: pointer;
            z-index: 1000; 
        }
        .nbs-flexisel-nav-left {
            left: 0;
        }
        .nbs-flexisel-nav-left:after {
            content: "<"; 
        }
        .nbs-flexisel-nav-right {
            right: 0; 
        }
        .nbs-flexisel-nav-right:after {
            content: ">"; 
        }
    </style>
</head>
<body>
    <p>
        At certain screen widths you can't scroll to the next image:<br/>
        Screen Width - 808px:broken<br />
        Screen Width - 809px:works<br />
        Screen Width - 810px:works<br />
        Screen Width - 811px:works<br />
        Screen Width - 812px:broken
    </p>
    <div class="video-gallery-wrapper">
        <ul class="video-thumbs"></ul>
    </div>
</body>
<script type="text/javascript">
    for (var i=0; i<5; i++) {
        $(".video-thumbs").append('<li class="video-thumb"><a class="video" href="javascript:void(0)"><img class="video-thumbnail-image" src="http://freetopwallpaper.com/wp-content/gallery/cat/cute-cats-wallpapers-background-35.jpg" alt="Test"/><span class="video-caption">blah blah blah</span></a></li>');
    }
    $(".video-thumbs").flexisel({
        enableResponsiveBreakpoints: true,
        clone: false,
        responsiveBreakpoints: {
            mobile: {
                changePoint: 579,
                visibleItems: 2
            },
            tablet: {
                changePoint: 580,
                visibleItems: 3
            },
            desktop: {
                changePoint: 900,
                visibleItems: 4
            }
        }
    });
</script>
</html>
```
